### PR TITLE
Add ability to throw objects towards deepmimic humanoid to check stability

### DIFF
--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/env/humanoid_stable_pd.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/env/humanoid_stable_pd.py
@@ -144,6 +144,7 @@ class HumanoidStablePD(object):
     self.setSimTime(0)
 
     self.resetPose()
+    self.thrown_body_ids = []
 
   def resetPose(self):
     #print("resetPose with self._frame=", self._frame, " and self._frameFraction=",self._frameFraction)
@@ -590,6 +591,9 @@ class HumanoidStablePD(object):
       #ignore self-collision
       if (p[1] == p[2]):
         continue
+      # ignore collisions with thrown objects
+      if p[1] in self.thrown_body_ids or p[2] in self.thrown_body_ids:
+        continue
       if (p[1] == self._sim_model):
         part = p[3]
       if (p[2] == self._sim_model):
@@ -795,3 +799,7 @@ class HumanoidStablePD(object):
     #print("com_reward=",com_reward)
 
     return reward
+
+  def getSimModelBasePosition(self):
+    return  self._pybullet_client\
+                .getBasePositionAndOrientation(self._sim_model)

--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/env/pybullet_deep_mimic_env.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/env/pybullet_deep_mimic_env.py
@@ -359,7 +359,12 @@ class PyBulletDeepMimicEnv(Env):
     self._humanoid.thrown_body_ids.append(body)
 
   def removeThrownObjects(self):
+    # Disable gui so that object removal does not cause stutter
+    self._pybullet_client.configureDebugVisualizer(self._pybullet_client.COV_ENABLE_RENDERING,0)
+
     for objectId in self._humanoid.thrown_body_ids:
       self._pybullet_client.removeBody(objectId)
 
     self._humanoid.thrown_body_ids = []
+
+    self._pybullet_client.configureDebugVisualizer(self._pybullet_client.COV_ENABLE_RENDERING,1)

--- a/examples/pybullet/gym/pybullet_envs/deep_mimic/testrl.py
+++ b/examples/pybullet/gym/pybullet_envs/deep_mimic/testrl.py
@@ -87,6 +87,9 @@ if __name__ == '__main__':
 
     if world.env.isKeyTriggered(keys, ' '):
       animating = not animating
+    if world.env.isKeyTriggered(keys, 'x'):
+      # print("Throwing object.")
+      world.env.hitWithObject()
     if (animating):
       update_world(world, timeStep)
       #animating=False


### PR DESCRIPTION
This pull request adds functionality to the deepmimic humanoid example file "testrl.py".
By pressing the 'x' button, balls are thrown towards the humanoid model, like in the original deepmimic repo.

This way you can interactively test how stable the policy is.

For future reference: run the testrl.py file like this:
python testrl.py --arg_file run_humanoid3d_backflip_args.txt

P.S. I noticed that the removeBody pybullet method can be quite slow removing all the thrown balls after the simulation finishes. (I might create an issue for this.)